### PR TITLE
get label demand from jenkins queue info

### DIFF
--- a/nodepool/builder.py
+++ b/nodepool/builder.py
@@ -254,18 +254,16 @@ class NodePoolBuilder(object):
         self._config = config
 
     def _validate_config(self):
-        if not self._config.gearman_servers.values():
-            raise RuntimeError('No gearman servers specified in config.')
-
         if not self._config.imagesdir:
             raise RuntimeError('No images-dir specified in config.')
 
     def _initializeGearmanWorker(self, worker, servers):
-        for server in servers:
-            worker.addServer(server.host, server.port)
+        if servers:
+            for server in servers:
+                worker.addServer(server.host, server.port)
 
-        self.log.debug('Waiting for gearman server')
-        worker.waitForServer()
+            self.log.debug('Waiting for gearman server')
+            worker.waitForServer()
 
     def _registerGearmanFunctions(self, images):
         self.log.debug('Registering gearman functions')

--- a/nodepool/cmd/__init__.py
+++ b/nodepool/cmd/__init__.py
@@ -31,6 +31,7 @@ class NodepoolApp(object):
                 raise Exception("Unable to read logging config file at %s" %
                                 fp)
             logging.config.fileConfig(fp)
+            logging.info('Logging configured from file %s' % fp)
         else:
             logging.basicConfig(level=logging.DEBUG,
                                 format='%(asctime)s %(levelname)s %(name)s: '


### PR DESCRIPTION
nodepool was updated to require gearman to calculate node launch demand.
I've done some experimentation with using gearman for calculating label
demand, as well as just using the jenkins API directly, and found that
using the API directly is very reliable, and makes it so that we don't
need gearman to be involved at all. As a result, this change does a few
things:

- The 'gearman_servers' config key is no longer required.
  - This was pretty easy to do. Since nodepool hasn't always required
    gearman, the config loader already does all the work to make sure
    a default value is set for this in the config object that gets
    passed around, and things using that value properly handle it being
    empty.
- The addition of german servers and the check to wait for them to
  be online before proceeding are now only done if german servers are
  confgured.
- nodepool's jenkins manager has received the ability to inspect the
  jenkins queue, and guess at label demand based on that queue.
  - There's an XXX-marked comment in that section that might make this
    change pulp-specific. If we ever wanted to submit this upstream,
    that would have to be resolved.
- Finally, nodepool itself combines all of the above to use the jenkins
  job queue directly to calculate label demand, allowing us to set node
  label min-ready values to 0; nodepool will spawn the nodes on-demand.
  This means we should now be using our openstack quota to its fullest,
  and if we start hitting quota caps again we are justified in asking
  for more resources.
- A few logging changes (both level and contents) have been made so that
  we see the information we actually want in the nodepool log at level
  INFO. More info is included at DEBUG if desired, but hopefully we'll
  get by running at INFO and still have a useful log.